### PR TITLE
Normalise vertical alignment in columns

### DIFF
--- a/src/utility-classes/_index.scss
+++ b/src/utility-classes/_index.scss
@@ -20,6 +20,7 @@
           &-wrapper > * {
             @include column-padding;
             display: table-cell;
+            vertical-align: top;
           }
 
           @for $j from 1 through gr(max-number) {


### PR DESCRIPTION
Vertical alignment defaults to baseline which can be problematic when the columns don't contain just text (see example below)

<img width="615" alt="screen shot 2018-10-05 at 18 09 21" src="https://user-images.githubusercontent.com/657586/46543795-7237ab00-c8ca-11e8-973d-b7f96ce3a752.png">
